### PR TITLE
Simplify FVTT initialization

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -121,11 +121,7 @@ function isFVTT(title) {
 }
 
 function fvttTitle(title) {
-    return title
-        .replace(" • Foundry Virtual Tabletop", "")
-        .replace(" • Foundry VTT", "")
-        .replace(" - Foundry VTT", "")
-        .replace(" - Foundry Virtual Tabletop", "");
+    return title.replace(" • Foundry Virtual Tabletop", "");
 }
 
 function urlMatches(url, matching) {

--- a/src/fvtt/content-script.js
+++ b/src/fvtt/content-script.js
@@ -57,6 +57,9 @@ function injectSettingsButton() {
 
 const observer = new window.MutationObserver(titleSet);
 observer.observe(document.getElementsByTagName("title")[0], { "childList": true });
+const currentTitle = document.getElementsByTagName("title")[0].textContent;
+if (currentTitle.includes("Foundry Virtual Tabletop"))
+    titleSet(null, observer);
 sendCustomEvent("disconnect");
 injectPageScript(chrome.runtime.getURL("libs/alertify.min.js"), () => {
     initializeAlertify();

--- a/src/fvtt/content-script.js
+++ b/src/fvtt/content-script.js
@@ -57,8 +57,6 @@ function injectSettingsButton() {
 
 const observer = new window.MutationObserver(titleSet);
 observer.observe(document.getElementsByTagName("title")[0], { "childList": true });
-if (document.getElementsByTagName("title")[0].textContent)
-    titleSet(null, observer);
 sendCustomEvent("disconnect");
 injectPageScript(chrome.runtime.getURL("libs/alertify.min.js"), () => {
     initializeAlertify();


### PR DESCRIPTION
## Summary
- remove check that triggered `titleSet` on page load
- revert `fvttTitle` cleanup logic to only strip the standard marker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844edfa55d483229795fdd6dd991356