### PR TITLE
Fix FVTT title check for new chat selector

### DIFF
--- a/src/fvtt/content-script.js
+++ b/src/fvtt/content-script.js
@@ -57,9 +57,7 @@ function injectSettingsButton() {
 
 const observer = new window.MutationObserver(titleSet);
 observer.observe(document.getElementsByTagName("title")[0], { "childList": true });
-const currentTitle = document.getElementsByTagName("title")[0].textContent;
-if (currentTitle.includes("Foundry Virtual Tabletop"))
-    titleSet(null, observer);
+titleSet(null, observer);
 sendCustomEvent("disconnect");
 injectPageScript(chrome.runtime.getURL("libs/alertify.min.js"), () => {
     initializeAlertify();

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -568,7 +568,7 @@ function disconnectAllEvents() {
 }
 
 function setTitle() {
-    const chatControls = $("#chat-controls");
+    const chatControls = $("#chat-controls, #chat-message");
     if (chatControls.length) {
         const title = document.getElementsByTagName("title")[0];
         const worldTitle = game.world.title || game.world.data?.title || "";


### PR DESCRIPTION
## Summary
- ensure chat log detection works with updated Foundry VTT DOM
- remove redundant title check in the FVTT content script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a2af9db748322b39d5af4d0b4c9ee